### PR TITLE
WSGI Hessian Server App

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,39 @@ Testing against `Caucho <http://hessian.caucho.com/>`_'s reference service::
   service = HessianProxy("http://hessian.caucho.com/test/test")
   print service.replyDate_1()
 
+Using `mustaine.server`
++++++++++++++++++++++++
+
+An object can be served via WSGI by wrapping it with the provided
+mustaine.server.WsgiApp.  An object's methods are only exposed
+if decorated with mustaine.server.exposed decorator.  For example::
+
+  from mustaine.server import exposed
+
+  class Calculator(object):
+      @exposed
+      def add(self, a, b):
+          return a + b
+
+      @exposed
+      def subtract(self, a, b):
+          return a - b
+
+The following code will serve a Calculator object on port 8080 using the
+Python reference WSGI server::
+
+  from wsgiref import simple_server
+  from mustaine.server import WsgiApp
+  s = simple_server.make_server('', 8080, WsgiApp(Calculator()))
+  s.serve_forever()
+
+This object can now be accessed over the network as already described::
+
+  >>> from mustaine.client import HessianProxy
+  >>> h = HessianProxy('http://localhost:8080/')
+  >>> h.add(2, 3)
+  5
+
 Source
 ------
 

--- a/mustaine/encoder.py
+++ b/mustaine/encoder.py
@@ -217,3 +217,9 @@ def encode_reply(reply):
 
     return encoded
 
+@encoder_for(Fault)
+@returns('fault')
+def encode_fault(fault):
+    encoded = ''.join(encode_keyval((key, getattr(fault, key))) for key in ['code', 'message', 'detail'])
+    return pack('>c', 'f') + encoded + 'z'
+

--- a/mustaine/protocol.py
+++ b/mustaine/protocol.py
@@ -124,7 +124,7 @@ class Object(object):
         return self.__meta_type
 
     def __repr__(self):
-        return "<{0} object at {1}>" % (self.__meta_type, hex(id(self)),)
+        return "<{0} object at {1}>".format(self.__meta_type, hex(id(self)))
 
     def __getstate__(self):
         # clear metadata for clean pickling

--- a/mustaine/server.py
+++ b/mustaine/server.py
@@ -41,7 +41,7 @@ class WsgiApp(object):
             post_data = environ['wsgi.input'].read(int(environ.get('CONTENT_LENGTH', '0')))
             response = self.hessian_call(post_data)
         except Exception, e:
-            fault = protocol.Fault('ServiceException', e.message, '')
+            fault = protocol.Fault('ServiceException', str(e), '')
             response = encode_reply(fault)
         start_response(STATUS, HEADERS)
         return [response]
@@ -53,9 +53,9 @@ class WsgiApp(object):
             func = self.functions[call.method]
             result = func(*call.args)
         except parser.ParseError, e:
-            result = protocol.Fault('ProtocolException', e.message, '')
+            result = protocol.Fault('ProtocolException', str(e), '')
         except KeyError:
             result = protocol.Fault('NoSuchMethodException', 'The requested method "{0}" does not exist.'.format(call.method), '')
         except Exception, e:
-            result = protocol.Fault('ServiceException', e.message, '')
+            result = protocol.Fault('ServiceException', str(e), '')
         return encode_reply(result)

--- a/mustaine/server.py
+++ b/mustaine/server.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from mustaine import parser, encoder, protocol
+from wsgiref import simple_server
+
+
+def exposed(func):
+    """Mark a function as exposed i.e. visible via Hessian."""
+    func._hessian_exposed = True
+    return func
+
+
+class WsgiApp(object):
+    """The Hessian server wsgi application."""
+
+    def __init__(self, obj):
+        """ Create a wsgi application which passes Hessian
+        calls to a server object.
+
+        obj:
+            The object to be exposed via Hessian
+        """
+        self.functions = {}
+        for i in dir(obj):
+            func = getattr(obj, i)
+            if not callable(func) or not hasattr(func, '_hessian_exposed') or not func._hessian_exposed:
+                continue
+            self.functions[i] = func
+
+    def __call__(self, environ, start_response):
+        """Standard wsgi function."""
+        post_data = environ['wsgi.input'].read(int(environ.get('CONTENT_LENGTH', '0')))
+        response = self.hessian_call(post_data)
+        status = '200 OK'
+        headers = [('Content-Type', 'application/x-hessian; charset=utf-8'), ]
+        start_response(status, headers)
+        return [response]
+
+    def hessian_call(self, post_data):
+        """Receive Hessian POST data and calls the appropriate function."""
+        call = parser.Parser().parse_string(post_data)
+        func = self.functions[call.method]
+        result = func(*call.args)
+        return encoder.encode_reply(protocol.Reply(result))[1]
+
+
+class Calculator(object):
+
+    @exposed
+    def add(self, a, b):
+        return a + b
+
+if __name__ == '__main__':
+    s = simple_server.make_server('', 8080, WsgiApp(Calculator()))
+    s.serve_forever()

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import sys
+import os
+# Use local mustaine
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import unittest
+
+from mustaine.server import exposed, WsgiApp
+
+
+class Calculator(object):
+    """Test Hessian server object."""
+
+    @exposed
+    def add(self, a, b):
+        return a + b
+
+    @exposed
+    def bad(self, a, b):
+        return 1 / 0
+
+    def hid(self, a, b):
+        return a + b
+
+
+class TestServer(unittest.TestCase):
+
+    def setUp(self):
+        self.wsgi_app = WsgiApp(Calculator())
+
+    def test_reply(self):
+        call = 'c\x01\x00m\x00\x03addI\x00\x00\x00\x05I\x00\x00\x00\x03z'  # call=add(5, 3)
+        result = self.wsgi_app.hessian_call(call)
+        self.assertEqual('r\x01\x00I\x00\x00\x00\x08z', result)   # reply=8
+
+    def test_exposed(self):
+        call = 'c\x01\x00m\x00\x03hidI\x00\x00\x00\x05I\x00\x00\x00\x03z'  # call=hid(5, 3)
+        result = self.wsgi_app.hessian_call(call)
+        fault = 'r\x01\x00f' \
+                'S\x00\x04codeS\x00\x15NoSuchMethodException' \
+                'S\x00\x07messageS\x00*The requested method "hid" does not exist.' \
+                'S\x00\x06detailS\x00\x00zz'
+        self.assertEqual(fault, result)   # reply=Fault
+
+    def test_no_method(self):
+        call = 'c\x01\x00m\x00\x03fooI\x00\x00\x00\x05I\x00\x00\x00\x03z'  # call=foo(5, 3)
+        result = self.wsgi_app.hessian_call(call)
+        fault = 'r\x01\x00f' \
+                'S\x00\x04codeS\x00\x15NoSuchMethodException' \
+                'S\x00\x07messageS\x00*The requested method "foo" does not exist.' \
+                'S\x00\x06detailS\x00\x00zz'
+        self.assertEqual(fault, result)   # reply=Fault
+        
+    def test_parse_error(self):
+        call = ''  # call=<malformed>
+        result = self.wsgi_app.hessian_call(call)
+        fault = 'r\x01\x00f' \
+                'S\x00\x04codeS\x00\x11ProtocolException' \
+                'S\x00\x07messageS\x00$Encountered unexpected end of stream' \
+                'S\x00\x06detailS\x00\x00zz'
+        self.assertEqual(fault, result)   # reply=Fault
+        
+    def test_service_exception(self):
+        call = 'c\x01\x00m\x00\x03badI\x00\x00\x00\x05I\x00\x00\x00\x03z'  # call=bad(5, 3)
+        result = self.wsgi_app.hessian_call(call)
+        fault = 'r\x01\x00fS\x00\x04code' \
+                'S\x00\x10ServiceExceptionS\x00\x07message' \
+                'S\x00"integer division or modulo by zero' \
+                'S\x00\x06detailS\x00\x00zz'
+        self.assertEqual(fault, result)   # reply=Fault
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implemented a basic WSGI app which serves a Python object via Hessian.  In doing so, encoders for protocol.Reply and protocol.Fault were implemented.  Only methods decorated with @exposed are made available to Hessian clients.

Example server:

```
from wsgiref import simple_server
from mustaine.server import WsgiApp, exposed

class Calculator(object):
    @exposed
    def add(self, a, b):
        return a + b

s = simple_server.make_server('', 8080, WsgiApp(Calculator()))
s.serve_forever()
```

Example client in an interactive session:

```
>>> from mustaine.client import HessianProxy
>>> h = HessianProxy('http://localhost:8080/')
>>> h.add(2, 3)
5
```
