### PR TITLE
Adds a __add__ operator for the binary class to handle the following exception:

### DIFF
--- a/mustaine/protocol.py
+++ b/mustaine/protocol.py
@@ -105,10 +105,9 @@ class Binary(object):
         self.value = value
     def __add__(self, value):
         if self.value == None:
-            self.value = value
+            return Binary(value)
         else:
-            self.value = self.value + value.value
-        return self
+            return Binary(self.value + value.value)
 
 
 class Remote(object):


### PR DESCRIPTION
  File "/opt/aui-6.9/lib/python2.6/site-packages/mustaine-0.1.5-py2.6.egg/mustaine/client.py", line 106, in **call**
    reply = self._parser.parse_stream(BufferedReader(response, buffer_size=self._buffer_size))
  File "/opt/aui-6.9/lib/python2.6/site-packages/mustaine-0.1.5-py2.6.egg/mustaine/parser.py", line 99, in parse_stream
    self._result.value = self._read_object(code)
  File "/opt/aui-6.9/lib/python2.6/site-packages/mustaine-0.1.5-py2.6.egg/mustaine/parser.py", line 146, in _read_object
    return fragment + self._read_object(next)
TypeError: unsupported operand type(s) for +: 'Binary' and 'Binary'
